### PR TITLE
Live, auto-updating stats (Scholar + GitHub)

### DIFF
--- a/.github/scripts/fetch-stats.py
+++ b/.github/scripts/fetch-stats.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Fetch live stats (Google Scholar via SerpApi, GitHub via public API) and
+write data/stats.json. Failures are non-fatal: a field that cannot be fetched
+keeps its previous value, so a transient outage never wipes the numbers.
+
+Env:
+  SERPAPI_KEY  SerpApi key (Google Scholar Author API). Optional.
+  GH_TOKEN     GitHub token (raises rate limit / private access). Optional.
+"""
+import datetime
+import json
+import os
+import pathlib
+import re
+import sys
+import urllib.parse
+import urllib.request
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+STATS = ROOT / "data" / "stats.json"
+
+SCHOLAR_AUTHOR_ID = "obMPBnEAAAAJ"
+GH_REPO = "aia-uclouvain/pydl8.5"
+
+
+def load():
+    try:
+        return json.loads(STATS.read_text())
+    except Exception:
+        return {}
+
+
+def get(url, headers=None):
+    req = urllib.request.Request(url, headers=headers or {})
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.loads(r.read().decode("utf-8")), dict(r.headers)
+
+
+def main():
+    stats = load()
+    stats.setdefault("scholar", {})
+    stats.setdefault("papers", {})
+    stats.setdefault("pydl85", {})
+    stats.pop("github", None)  # legacy key, superseded by "pydl85"
+
+    # ---- Google Scholar via SerpApi -------------------------------------
+    key = os.environ.get("SERPAPI_KEY")
+    if key:
+        try:
+            url = "https://serpapi.com/search.json?" + urllib.parse.urlencode({
+                "engine": "google_scholar_author",
+                "author_id": SCHOLAR_AUTHOR_ID,
+                "num": "100",
+                "api_key": key,
+            })
+            d, _ = get(url)
+            for row in d.get("cited_by", {}).get("table", []):
+                if "citations" in row:
+                    stats["scholar"]["citations"] = row["citations"]["all"]
+                if "h_index" in row:
+                    stats["scholar"]["hIndex"] = row["h_index"]["all"]
+            for art in d.get("articles", []):
+                title = (art.get("title") or "").lower()
+                cited = art.get("cited_by", {}).get("value")
+                if cited is None:
+                    continue
+                if "caching branch-and-bound" in title:
+                    stats["papers"]["aaai2020"] = cited
+                elif title.startswith("pydl8.5"):
+                    stats["papers"]["ijcai2021"] = cited
+        except Exception as e:  # noqa: BLE001
+            print(f"[scholar] skipped: {e}", file=sys.stderr)
+    else:
+        print("[scholar] SERPAPI_KEY not set; keeping previous values", file=sys.stderr)
+
+    # ---- GitHub (releases = tags, plus commits + stars) -----------------
+    # The repo ships versions as git tags (no GitHub Release objects), so the
+    # "21 releases" figure is the tag count, not /releases or PyPI versions.
+    headers = {"Accept": "application/vnd.github+json", "User-Agent": "stats-bot"}
+    tok = os.environ.get("GH_TOKEN")
+    if tok:
+        headers["Authorization"] = "Bearer " + tok
+    try:
+        d, _ = get(f"https://api.github.com/repos/{GH_REPO}", headers)
+        stats["pydl85"]["stars"] = d.get("stargazers_count")
+    except Exception as e:  # noqa: BLE001
+        print(f"[github/repo] skipped: {e}", file=sys.stderr)
+    try:
+        tags, _ = get(f"https://api.github.com/repos/{GH_REPO}/tags?per_page=100", headers)
+        if isinstance(tags, list):
+            stats["pydl85"]["releases"] = len(tags)  # accurate up to 100 tags
+    except Exception as e:  # noqa: BLE001
+        print(f"[github/tags] skipped: {e}", file=sys.stderr)
+    try:
+        _, h = get(f"https://api.github.com/repos/{GH_REPO}/commits?per_page=1", headers)
+        m = re.search(r'[?&]page=(\d+)>;\s*rel="last"', h.get("Link", ""))
+        if m:
+            stats["pydl85"]["commits"] = int(m.group(1))
+    except Exception as e:  # noqa: BLE001
+        print(f"[github/commits] skipped: {e}", file=sys.stderr)
+
+    stats["updatedAt"] = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
+
+    STATS.parent.mkdir(parents=True, exist_ok=True)
+    STATS.write_text(json.dumps(stats, indent=2, ensure_ascii=False) + "\n")
+    print(json.dumps(stats, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -1,0 +1,41 @@
+name: Update live stats
+
+on:
+  schedule:
+    - cron: "23 5 * * *"   # daily, ~05:23 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-stats
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Fetch stats
+        env:
+          SERPAPI_KEY: ${{ secrets.SERPAPI_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python .github/scripts/fetch-stats.py
+
+      - name: Commit if changed
+        run: |
+          if git diff --quiet -- data/stats.json; then
+            echo "No change in data/stats.json."
+          else
+            git config user.name "stats-bot"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add data/stats.json
+            git commit -m "chore: update live stats"
+            git push
+          fi

--- a/app.js
+++ b/app.js
@@ -9,6 +9,29 @@
   var yr = document.querySelector("[data-year]");
   if (yr) yr.textContent = String(new Date().getFullYear());
 
+  /* ---- live stats ------------------------------------------------------ */
+  /* Numbers come from data/stats.json, refreshed daily by a GitHub Action
+     (Google Scholar via SerpApi + GitHub API). The HTML ships with the last
+     known values, so a failed fetch or no-JS just keeps those. */
+  (function () {
+    var hooks = document.querySelectorAll("[data-stat]");
+    if (!hooks.length) return;
+    fetch("/data/stats.json", { cache: "no-cache" })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (data) {
+        if (!data) return;
+        hooks.forEach(function (el) {
+          var value = el.getAttribute("data-stat").split(".").reduce(function (obj, key) {
+            return obj == null ? obj : obj[key];
+          }, data);
+          if (value === null || value === undefined || value === "") return;
+          el.textContent =
+            typeof value === "number" ? value.toLocaleString("en-US") : String(value);
+        });
+      })
+      .catch(function () {});
+  })();
+
   /* ---- sticky header scrolled state ------------------------------------ */
   var head = document.querySelector(".site-head");
   if (head) {

--- a/data/stats.json
+++ b/data/stats.json
@@ -1,0 +1,16 @@
+{
+  "scholar": {
+    "citations": 290,
+    "hIndex": 4
+  },
+  "papers": {
+    "aaai2020": 218,
+    "ijcai2021": 49
+  },
+  "pydl85": {
+    "releases": 21,
+    "commits": 634,
+    "stars": 69
+  },
+  "updatedAt": "2026-06-08"
+}

--- a/index.html
+++ b/index.html
@@ -155,24 +155,24 @@
 
         <div class="ledger">
           <div class="ledger-row" data-reveal>
-            <div class="ledger-fig">218</div>
+            <div class="ledger-fig"><span data-stat="papers.aaai2020">218</span></div>
             <div class="ledger-body">
               <h3>Citations, AAAI 2020</h3>
               <p>“Learning Optimal Decision Trees Using Caching Branch-and-Bound Search.” Presented at AAAI, New York.</p>
             </div>
           </div>
           <div class="ledger-row" data-reveal>
-            <div class="ledger-fig">290 <span class="u">/ h-index 4</span></div>
+            <div class="ledger-fig"><span data-stat="scholar.citations">290</span> <span class="u">/ h-index <span data-stat="scholar.hIndex">4</span></span></div>
             <div class="ledger-body">
               <h3>Total citations</h3>
               <p>Across AAAI, IJCAI, ECML PKDD, IDA, and CPAIOR. Tracked on Google Scholar.</p>
             </div>
           </div>
           <div class="ledger-row" data-reveal>
-            <div class="ledger-fig">21 <span class="u">releases</span></div>
+            <div class="ledger-fig"><span data-stat="pydl85.releases">21</span> <span class="u">releases</span></div>
             <div class="ledger-body">
               <h3>PyDL8.5, open source</h3>
-              <p>scikit-learn-compatible C++/Cython/Python library on PyPI. 600+ commits, CI on Linux, macOS and Windows.</p>
+              <p>scikit-learn-compatible C++/Cython/Python library on PyPI. <span data-stat="pydl85.commits">600+</span> commits, CI on Linux, macOS and Windows.</p>
             </div>
           </div>
           <div class="ledger-row" data-reveal>
@@ -359,7 +359,7 @@
               <p class="authors"><b>Aglin G.</b>, Nijssen S., Schaus P.</p>
               <p class="note">Presented at AAAI, New York.</p>
             </div>
-            <div class="pub-cite"><b>218</b> cites</div>
+            <div class="pub-cite"><b data-stat="papers.aaai2020">218</b> cites</div>
           </article>
 
           <article class="pub" data-reveal>
@@ -368,7 +368,7 @@
               <h3>PyDL8.5: A Library for Learning Optimal Decision Trees</h3>
               <p class="authors"><b>Aglin G.</b>, Nijssen S., Schaus P.</p>
             </div>
-            <div class="pub-cite"><b>49</b> cites</div>
+            <div class="pub-cite"><b data-stat="papers.ijcai2021">49</b> cites</div>
           </article>
 
           <article class="pub" data-reveal>
@@ -535,7 +535,7 @@
           <a href="mailto:aglingael@gmail.com">Email<span class="handle">aglingael@gmail.com</span></a>
           <a href="https://www.linkedin.com/in/aglingael/" target="_blank" rel="noopener">LinkedIn<span class="handle">/in/aglingael</span></a>
           <a href="https://github.com/aglingael" target="_blank" rel="noopener">GitHub<span class="handle">@aglingael</span></a>
-          <a href="https://scholar.google.com/citations?user=obMPBnEAAAAJ" target="_blank" rel="noopener">Google Scholar<span class="handle">290 citations</span></a>
+          <a href="https://scholar.google.com/citations?user=obMPBnEAAAAJ" target="_blank" rel="noopener">Google Scholar<span class="handle"><span data-stat="scholar.citations">290</span> citations</span></a>
           <a href="https://orcid.org/0000-0002-6760-4752" target="_blank" rel="noopener">ORCID<span class="handle">0000-0002-6760-4752</span></a>
         </nav>
       </div>

--- a/publications.html
+++ b/publications.html
@@ -65,7 +65,7 @@
           <span class="sec-num">★</span>
           <h2 class="sec-title">Selected papers</h2>
           <p class="sec-note">
-            290 total citations · h-index 4.
+            <span data-stat="scholar.citations">290</span> total citations · h-index <span data-stat="scholar.hIndex">4</span>.
             <a class="link" href="https://scholar.google.com/citations?user=obMPBnEAAAAJ" target="_blank" rel="noopener">Google Scholar →</a>
           </p>
         </header>
@@ -78,7 +78,7 @@
               <p class="authors"><b>Aglin G.</b>, Nijssen S., Schaus P.</p>
               <p class="note">Proceedings of the AAAI Conference on Artificial Intelligence. Presented at AAAI, New York.</p>
             </div>
-            <div class="pub-cite"><b>218</b> cites</div>
+            <div class="pub-cite"><b data-stat="papers.aaai2020">218</b> cites</div>
           </article>
 
           <article class="pub">
@@ -88,7 +88,7 @@
               <p class="authors"><b>Aglin G.</b>, Nijssen S., Schaus P.</p>
               <p class="note">International Joint Conference on Artificial Intelligence (demo / system track).</p>
             </div>
-            <div class="pub-cite"><b>49</b> cites</div>
+            <div class="pub-cite"><b data-stat="papers.ijcai2021">49</b> cites</div>
           </article>
 
           <article class="pub">


### PR DESCRIPTION
Removes the need to manually edit citation / repo numbers. They now come from `data/stats.json`, refreshed daily by a GitHub Action, and rendered into `[data-stat]` hooks client-side. The HTML still ships the last known values, so a failed fetch or no-JS keeps them.

## How it works
- **`.github/workflows/update-stats.yml`** — daily cron (`05:23 UTC`) + manual `workflow_dispatch`; commits `data/stats.json` only when it changes.
- **`.github/scripts/fetch-stats.py`** (stdlib only):
  - Google Scholar citations + h-index + per-paper citations via **SerpApi** (needs a `SERPAPI_KEY` repo secret).
  - PyDL8.5 **releases = GitHub tag count** (the repo has no GitHub Release objects; PyPI only has 9 versions, tags are the 21), **commits** via the `commits` Link header, **stars** via the repo API.
  - Best-effort per field: a fetch failure keeps the previous value (never wipes the numbers).
- **`app.js`** fetches `/data/stats.json` and fills `[data-stat]` elements, with a silent fallback.

## Setup required (one-time, for Scholar)
Add a `SERPAPI_KEY` repository secret (free tier: 100 searches/month; daily use ≈ 30). Until then, the Action still updates the GitHub numbers and keeps the current Scholar values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)