### PR TITLE
Move portrait into the hero (first fold)

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
     <section class="hero" id="top">
       <div class="wrap">
         <div class="hero-text">
+          <img class="hero-portrait" src="/assets/img/portrait.jpg" width="640" height="640" alt="Portrait of Gaël Aglin" data-reveal />
           <span class="hero-eyebrow" data-reveal><span class="dot"></span>Senior Data Scientist · Ph.D.</span>
           <h1 data-reveal>Gaël<br />Aglin<span class="ph">.</span></h1>
           <p class="hero-role" data-reveal>Production ML · Decision Science · GenAI</p>
@@ -230,7 +231,6 @@
           </div>
 
           <aside class="about-side" data-reveal>
-            <img class="about-portrait" src="/assets/img/portrait.jpg" width="640" height="640" alt="Portrait of Gaël Aglin" loading="lazy" />
             <div class="blk">
               <h4>Currently</h4>
               <p class="big">Senior Data Scientist</p>

--- a/styles.css
+++ b/styles.css
@@ -582,16 +582,18 @@ h1, h2, h3, h4 {
   letter-spacing: -0.01em;
 }
 
-.about-portrait {
-  width: 100%;
-  height: auto;
-  max-width: 200px;
-  aspect-ratio: 1 / 1;
+.hero-portrait {
+  width: 116px;
+  height: 116px;
   object-fit: cover;
-  object-position: center 30%;
-  border-radius: 14px;
+  object-position: center 26%;
+  border-radius: 20px;
   border: 1px solid var(--line);
-  box-shadow: 0 14px 30px -20px oklch(0.23 0.014 55 / 0.55);
+  box-shadow: 0 16px 34px -22px oklch(0.23 0.014 55 / 0.6);
+  margin-bottom: 1.6rem;
+}
+@media (min-width: 940px) {
+  .hero-portrait { width: 128px; height: 128px; }
 }
 
 /* ----- Publications / research ------------------------------------------ */


### PR DESCRIPTION
Per the **impeccable** brand verdict: on a recruiter-facing personal site the face should be in the first fold, not in fold 2. Moves the portrait to the top of the hero identity block (rounded frame matching the monogram), keeps the decision tree as the right-hand concept visual, and removes the now-duplicate portrait from the Profile aside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)