### PR TITLE
Fix oversized hero portrait on mobile (stale-CSS fallback)

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
     <section class="hero" id="top">
       <div class="wrap">
         <div class="hero-text">
-          <img class="hero-portrait" src="/assets/img/portrait.jpg" width="640" height="640" alt="Portrait of Gaël Aglin" data-reveal />
+          <img class="hero-portrait" src="/assets/img/portrait.jpg" width="128" height="128" alt="Portrait of Gaël Aglin" data-reveal />
           <span class="hero-eyebrow" data-reveal><span class="dot"></span>Senior Data Scientist · Ph.D.</span>
           <h1 data-reveal>Gaël<br />Aglin<span class="ph">.</span></h1>
           <p class="hero-role" data-reveal>Production ML · Decision Science · GenAI</p>


### PR DESCRIPTION
The hero `<img>` declared its `640x640` intrinsic size. When a browser served a **cached stylesheet** without the `.hero-portrait` rule (HTML/CSS version skew), the image fell back to 640px capped at 100% width and filled the screen on mobile.

Fix: set the `width`/`height` attributes to the real display size (`128`), so the portrait degrades to a small, correctly-proportioned image even when the CSS rule isn't applied. The intended rendering (116px desktop/mobile, 128px ≥940px) is unchanged; verified clean at 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)