### PR TITLE
Add Adressage Cotonou project (2x2 projects grid)

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,6 +425,21 @@
 
           <article class="project" data-reveal>
             <div class="project-top">
+              <span class="project-kicker">Civic tech · 2026</span>
+            </div>
+            <h3>Adressage Cotonou</h3>
+            <p>Participatory street-addressing for Cotonou, Benin, where more than 9 in 10 streets have no official name. A Python pipeline (OpenStreetMap + Google Open Buildings) generates culturally-rooted names for 7,331 fully-named streets; a MapLibre web app lets citizens explore, propose and vote, as a citizen contribution toward official adoption and reproducible for any Benin commune.</p>
+            <div class="xp-tags">
+              <span class="tag">Next.js</span><span class="tag">MapLibre</span><span class="tag">Python</span><span class="tag">PostgreSQL</span><span class="tag">OpenStreetMap</span>
+            </div>
+            <a class="project-link" href="https://adressage.up.railway.app" target="_blank" rel="noopener">
+              adressage.up.railway.app
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M7 17 17 7M9 7h8v8"/></svg>
+            </a>
+          </article>
+
+          <article class="project" data-reveal>
+            <div class="project-top">
               <span class="project-kicker">Solo B2B SaaS · 2024 – now</span>
             </div>
             <h3>rendoc.africa</h3>

--- a/styles.css
+++ b/styles.css
@@ -643,7 +643,7 @@ h1, h2, h3, h4 {
 /* ----- Projects --------------------------------------------------------- */
 .projects { display: grid; gap: 1.5rem; }
 @media (min-width: 820px) {
-  .projects { grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); }
+  .projects { grid-template-columns: repeat(2, 1fr); }
 }
 .project {
   position: relative;


### PR DESCRIPTION
Adds a project card for **adressage.up.railway.app** — a participatory street-addressing platform for Cotonou, Benin: a Python data pipeline (OpenStreetMap + Google Open Buildings) names 7,331 streets with heritage toponyms, and a MapLibre/Next.js app on Railway lets citizens explore, propose and vote, framed as a citizen contribution toward official adoption.

Also switches the projects section from a 3-column auto-fit grid to an explicit **2-column grid** (≥820px) so the four cards form a balanced 2×2 instead of a lonely 3+1. Mobile stays single-column. Verified both rows at desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)