### PR TITLE
Reframe addressing project as Benin-wide

### DIFF
--- a/index.html
+++ b/index.html
@@ -427,8 +427,8 @@
             <div class="project-top">
               <span class="project-kicker">Civic tech · 2026</span>
             </div>
-            <h3>Adressage Cotonou</h3>
-            <p>Participatory street-addressing for Cotonou, Benin, where more than 9 in 10 streets have no official name. A Python pipeline (OpenStreetMap + Google Open Buildings) generates culturally-rooted names for 7,331 fully-named streets; a MapLibre web app lets citizens explore, propose and vote, as a citizen contribution toward official adoption and reproducible for any Benin commune.</p>
+            <h3>Adressage Bénin</h3>
+            <p>Participatory street-addressing for Benin, commune by commune, where most streets still have no official name. A Python pipeline (OpenStreetMap + Google Open Buildings) generates culturally-rooted heritage names, and a MapLibre web app lets citizens explore, propose and vote, as a citizen contribution toward official adoption. First commune: Cotonou, with 7,331 streets fully named.</p>
             <div class="xp-tags">
               <span class="tag">Next.js</span><span class="tag">MapLibre</span><span class="tag">Python</span><span class="tag">PostgreSQL</span><span class="tag">OpenStreetMap</span>
             </div>


### PR DESCRIPTION
The project addresses **Benin** nationally (commune by commune), not just Cotonou. Renames the card to "Adressage Bénin" and frames Cotonou as the first commune (7,331 streets already named).

🤖 Generated with [Claude Code](https://claude.com/claude-code)